### PR TITLE
Set enable_ecs_service_role to false if there is no lb for service

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 <!-- markdownlint-disable -->
 # terraform-aws-ecs-alb-service-task [![Latest Release](https://img.shields.io/github/release/cloudposse/terraform-aws-ecs-alb-service-task.svg)](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task/releases/latest) [![Slack Community](https://slack.cloudposse.com/badge.svg)](https://slack.cloudposse.com)
 <!-- markdownlint-restore -->
@@ -29,7 +30,6 @@
 
 Terraform module to create an ECS Service for a web app (task), and an ALB target group to route requests.
 
-
 ---
 
 This project is part of our comprehensive ["SweetOps"](https://cpco.io/sweetops) approach towards DevOps.
@@ -54,7 +54,6 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 We literally have [*hundreds of terraform modules*][terraform_modules] that are Open Source and well-maintained. Check them out!
-
 
 
 
@@ -393,6 +392,7 @@ Like this project? Please give it a ★ on [our GitHub](https://github.com/cloud
 Are you using this project or any of our other projects? Consider [leaving a testimonial][testimonial]. =)
 
 
+
 ## Related Projects
 
 Check out these related projects.
@@ -406,8 +406,6 @@ Check out these related projects.
 - [terraform-aws-ecs-cloudwatch-sns-alarms](https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms) - Terraform module to create CloudWatch Alarms on ECS Service level metrics
 - [terraform-aws-ecs-container-definition](https://github.com/cloudposse/terraform-aws-ecs-container-definition) - Terraform module to generate well-formed JSON documents that are passed to the aws_ecs_task_definition Terraform resource
 - [terraform-aws-lb-s3-bucket](https://github.com/cloudposse/terraform-aws-lb-s3-bucket) - Terraform module to provision an S3 bucket with built in IAM policy to allow AWS Load Balancers to ship access logs.
-
-
 
 ## Help
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   enabled                 = module.this.enabled
-  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) <= 1
+  enable_ecs_service_role = module.this.enabled && var.network_mode != "awsvpc" && length(var.ecs_load_balancers) == 1
 }
 
 module "task_label" {


### PR DESCRIPTION
When creating service, and there is no LB defined "You cannot specify an IAM role for services that require a service linked role."
Set enable_ecs_service_role to false when there is 0 LB or more than 1.

## what
When creating service with network mode != awsvpc and there is no LB defined it throws error: "You cannot specify an IAM role for services that require a service linked.

## why
When setting value enable_ecs_service_role we check if there is no more than 1 LB, but less than 1 is 0 and we can't assign IAM role when it is no LB and network mode is bridge, host or none.

## solution
Set `enable_ecs_service_role` to `false` when there is 0 LB or more than 1 when network mode is not `awsvpc`

